### PR TITLE
Fix broken shortcuts.py due to plist.Data deprecation

### DIFF
--- a/shortcuts/shortcut.py
+++ b/shortcuts/shortcut.py
@@ -171,7 +171,7 @@ class Shortcut:
         # todo: change me
         return {
             'WFWorkflowIconGlyphNumber': 59511,
-            'WFWorkflowIconImageData': plistlib.Data(b''),
+            'WFWorkflowIconImageData': bytes(b''),
             'WFWorkflowIconStartColor': 431817727,
         }
 


### PR DESCRIPTION
When you try to run `shortcuts.py`, you'll get the following error right now:
```
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "…/shortcuts/shortcut.py", line 77, in dump
    self._get_dumper_class(file_format)(shortcut=self).dump(file_object)
  File "…/shortcuts/dump.py", line 39, in dump
    plistlib.loads(self.dumps().encode('utf-8')),  # type: ignore
  File "…/shortcuts/dump.py", line 51, in dumps
    'WFWorkflowIcon': self.shortcut._get_icon(),
  File "…/shortcuts/shortcut.py", line 174, in _get_icon
    'WFWorkflowIconImageData': plistlib.Data(b''),
AttributeError: module 'plistlib' has no attribute 'Data'
```

This is because `plistlib.Data` has been deprecated since 3.4. If this is just changed to `bytes(b'')`, all is good!